### PR TITLE
arquitetura arm64 ignorada para builds de iOS simulator

### DIFF
--- a/SambaPlayer.xcodeproj/project.pbxproj
+++ b/SambaPlayer.xcodeproj/project.pbxproj
@@ -941,7 +941,7 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator14.3]" = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -976,7 +976,7 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator14.3]" = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
Arquitetura arm64 ignorada para builds de iOS simulator.